### PR TITLE
Fixed servers and change ItemEntityMixin.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 			url "https://maven.shedaniel.me/"
 		}
 		maven {
-			url "https://files.minecraftforge.net/maven/"
+			url "https://maven.minecraftforge.net/"
 		}
 		gradlePluginPortal()
 	}

--- a/src/main/java/virtuoel/pehkui/Pehkui.java
+++ b/src/main/java/virtuoel/pehkui/Pehkui.java
@@ -46,11 +46,8 @@ public class Pehkui
 		ArgumentTypes.register(id("scale_operation").toString(), ScaleOperationArgumentType.class, new ConstantArgumentSerializer<>(ScaleOperationArgumentType::operation));
 		
 		PehkuiEntitySelectorOptions.register();
-		
-		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () ->
-		{
-			PehkuiPacketHandler.init();
-		});
+
+		PehkuiPacketHandler.init();
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/virtuoel/pehkui/mixin/ItemEntityMixin.java
+++ b/src/main/java/virtuoel/pehkui/mixin/ItemEntityMixin.java
@@ -1,21 +1,26 @@
 package virtuoel.pehkui.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 import virtuoel.pehkui.util.ScaleUtils;
 
 @Mixin(ItemEntity.class)
 public class ItemEntityMixin
 {
-	@ModifyConstant(method = "tryMerge", constant = @Constant(doubleValue = 0.5D))
-	private double tryMergeModifyWidth(double value)
+	@ModifyArgs(method = "tryMerge()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/Box;expand(DDD)Lnet/minecraft/util/math/Box;"))
+	private void tryMergeModifyWidth(Args args)
 	{
 		final float scale = ScaleUtils.getWidthScale((Entity) (Object) this);
-		
-		return scale != 1.0F ? scale * value : value;
+		if (scale == 1.0F)
+			return;
+		int dx = args.size() - 3;
+		int dz = args.size() - 1;
+		args.set(dx, args.<Double>get(dx) * scale);
+		args.set(dz, args.<Double>get(dz) * scale);
 	}
 }

--- a/src/main/java/virtuoel/pehkui/network/ScalePacket.java
+++ b/src/main/java/virtuoel/pehkui/network/ScalePacket.java
@@ -4,10 +4,13 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.network.NetworkEvent;
 import virtuoel.pehkui.api.ScaleData;
 import virtuoel.pehkui.api.ScaleRegistries;
@@ -36,6 +39,9 @@ public class ScalePacket
 		this.typeId = typeId;
 		this.nbt = nbt;
 	}
+
+	@OnlyIn(Dist.CLIENT)
+	private static ClientWorld getClientWorld() { return MinecraftClient.getInstance().world; }
 	
 	public static void handle(ScalePacket msg, Supplier<NetworkEvent.Context> ctx)
 	{
@@ -43,8 +49,7 @@ public class ScalePacket
 		{
 			if (ScaleRegistries.SCALE_TYPES.containsKey(msg.typeId))
 			{
-				MinecraftClient client = MinecraftClient.getInstance();
-				for (final Entity e : client.world.getEntities())
+				for (final Entity e : getClientWorld().getEntities())
 				{
 					if (e.getUuid().equals(msg.uuid))
 					{


### PR DESCRIPTION
This is a patch for Forge, it fixes the networking issues due to the channel not being registered at the right time on the server, as well as a change to ItemEntityMixin to restore compatibility with the mod performant.