### PR TITLE
Condense syncScales into single packet.

### DIFF
--- a/src/main/java/virtuoel/pehkui/util/ScaleUtils.java
+++ b/src/main/java/virtuoel/pehkui/util/ScaleUtils.java
@@ -247,20 +247,17 @@ public class ScaleUtils
 			}
 		}
 
-		if(count == 0) {
-			entity.world.getProfiler().pop();
-			return;
+		if(count != 0) {
+			// Update count
+			int index = packetByteBuf.writerIndex();
+
+			packetByteBuf.writerIndex(countHead);
+			packetByteBuf.writeByte(count);
+
+			packetByteBuf.writerIndex(index);
+
+			packetSender.accept(new CustomPayloadS2CPacket(Pehkui.SCALE_PACKET, packetByteBuf));
 		}
-
-		// Update count
-		int index = packetByteBuf.writerIndex();
-
-		packetByteBuf.writerIndex(countHead);
-		packetByteBuf.writeByte(count);
-
-		packetByteBuf.writerIndex(index);
-
-		packetSender.accept(new CustomPayloadS2CPacket(Pehkui.SCALE_PACKET, packetByteBuf));
 	}
 	
 	public static float getEyeHeightScale(Entity entity)

--- a/src/main/java/virtuoel/pehkui/util/ScaleUtils.java
+++ b/src/main/java/virtuoel/pehkui/util/ScaleUtils.java
@@ -221,7 +221,6 @@ public class ScaleUtils
 	
 	public static void syncScales(Entity entity, Consumer<Packet<?>> packetSender, Predicate<ScaleData> condition, boolean unmark)
 	{
-		entity.world.getProfiler().push("syncScales");
 		final int id = entity.getId();
 		final PacketByteBuf packetByteBuf = new PacketByteBuf(Unpooled.buffer()).writeVarInt(id);
 
@@ -262,7 +261,6 @@ public class ScaleUtils
 		packetByteBuf.writerIndex(index);
 
 		packetSender.accept(new CustomPayloadS2CPacket(Pehkui.SCALE_PACKET, packetByteBuf));
-		entity.world.getProfiler().pop();
 	}
 	
 	public static float getEyeHeightScale(Entity entity)


### PR DESCRIPTION
Instead of sending a separate packet for each dirty ``SCALE_TYPE`` this sends one bigger packet instead.

Should improve performance as it decreases the amount of packet send calls & buffer allocations.

At worst it adds 1 byte of data to the packet if only one ``SCALE_TYPE`` is updated.