### PR TITLE
[Fabric] prevent negative-dimension crashes from commands

### DIFF
--- a/src/main/java/virtuoel/pehkui/api/ScaleType.java
+++ b/src/main/java/virtuoel/pehkui/api/ScaleType.java
@@ -115,8 +115,12 @@ public class ScaleType
 		private int defaultTickDelay = 20;
 		private float defaultMinPositiveScale = ScaleUtils.DEFAULT_MINIMUM_POSITIVE_SCALE;
 		private float defaultMaxPositiveScale = ScaleUtils.DEFAULT_MAXIMUM_POSITIVE_SCALE;
+		private boolean forbidsNegativeScale = false;
 		private ToDoubleBiFunction<ScaleData, Double> baseScaleClampFunction = (scaleData, newScale) ->
 		{
+			if (forbidsNegativeScale && newScale < 0) {
+				newScale = -newScale;
+			}
 			if (newScale > defaultMaxPositiveScale)
 			{
 				return defaultMaxPositiveScale;
@@ -134,6 +138,9 @@ public class ScaleType
 		};
 		private ToDoubleBiFunction<ScaleData, Double> targetScaleClampFunction = (scaleData, newScale) ->
 		{
+			if (forbidsNegativeScale && newScale < 0) {
+				newScale = -newScale;
+			}
 			if (newScale > defaultMaxPositiveScale)
 			{
 				return defaultMaxPositiveScale;
@@ -227,6 +234,11 @@ public class ScaleType
 		public Builder addDependentModifier(ScaleModifier scaleModifier)
 		{
 			this.dependentModifiers.add(scaleModifier);
+			return this;
+		}
+
+		public Builder forbidsNegativeScale() {
+			this.forbidsNegativeScale = true;
 			return this;
 		}
 		

--- a/src/main/java/virtuoel/pehkui/api/ScaleTypes.java
+++ b/src/main/java/virtuoel/pehkui/api/ScaleTypes.java
@@ -77,7 +77,8 @@ public class ScaleTypes
 	private static ScaleType registerDimensionScale(String path, ScaleModifier valueModifier, ScaleModifier... dependantModifiers)
 	{
 		final ScaleType.Builder builder = ScaleType.Builder.create()
-			.affectsDimensions();
+			.affectsDimensions()
+			.forbidsNegativeScale();
 		
 		if (valueModifier != null)
 		{

--- a/src/main/java/virtuoel/pehkui/server/command/ScaleCommand.java
+++ b/src/main/java/virtuoel/pehkui/server/command/ScaleCommand.java
@@ -83,7 +83,7 @@ public class ScaleCommand
 									final ScaleData data = type.getScaleData(e);
 									final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 									
-									data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+									data.setTargetScale((float) type.clampTargetScale(data, operation.apply(data.getTargetScale(), scale)));
 								}
 								
 								return 1;
@@ -97,7 +97,7 @@ public class ScaleCommand
 							final ScaleData data = type.getScaleData(context.getSource().getEntityOrThrow());
 							final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 							
-							data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+							data.setTargetScale((float) type.clampTargetScale(data, operation.apply(data.getTargetScale(), scale)));
 							
 							return 1;
 						})
@@ -113,8 +113,8 @@ public class ScaleCommand
 							{
 								final ScaleData data = ScaleTypes.BASE.getScaleData(e);
 								final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
-								
-								data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+
+								data.setTargetScale((float) ScaleTypes.BASE.clampTargetScale(data, operation.apply(data.getTargetScale(), scale)));
 							}
 							
 							return 1;
@@ -126,8 +126,8 @@ public class ScaleCommand
 						
 						final ScaleData data = ScaleTypes.BASE.getScaleData(context.getSource().getEntityOrThrow());
 						final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
-						
-						data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+
+						data.setTargetScale((float) ScaleTypes.BASE.clampTargetScale(data, operation.apply(data.getTargetScale(), scale)));
 						
 						return 1;
 					})
@@ -173,7 +173,7 @@ public class ScaleCommand
 													max = temp;
 												}
 												
-												data.setTargetScale(min + (RANDOM.nextFloat() * (max - min)));
+												data.setTargetScale((float) type.clampTargetScale(data, min + (RANDOM.nextFloat() * (max - min))));
 											}
 											
 											return 1;
@@ -202,7 +202,7 @@ public class ScaleCommand
 											max = temp;
 										}
 										
-										data.setTargetScale(min + (RANDOM.nextFloat() * (max - min)));
+										data.setTargetScale((float) type.clampTargetScale(data, min + (RANDOM.nextFloat() * (max - min))));
 										
 										return 1;
 									})


### PR DESCRIPTION
Right now, the `/scale` operation commands allow players to end up with negative scales. This is completely behavior, but I've found through experimentation that setting a scale that affects dimension to a negative number results in the game freezing. I've added a new property to `ScaleType.Builder` that allows a scale type to mark itself as forbidding negative scale, and all built-in scale types that affect dimensions take on this property.

If this was my own codebase, I think I would forbid negative scale for all built-in scale types - they all are effectively meaningless at negative scale and work practically identically to having a scale of 0. However, I've only limited it to the type that causes these crashes according to my testing.

Current behavior when a value is negative inverts the value back to being positive; if you would like it to instead default to the minimum positive scale let me know and I can implement that.