### PR TITLE
Remove redundant synchronization and scales late-init

### DIFF
--- a/src/main/java/virtuoel/pehkui/mixin/EntityMixin.java
+++ b/src/main/java/virtuoel/pehkui/mixin/EntityMixin.java
@@ -40,46 +40,27 @@ public abstract class EntityMixin implements PehkuiEntityExtensions
 	@Shadow boolean onGround;
 	@Shadow boolean firstUpdate;
 	
-	private Map<ScaleType, ScaleData> pehkui_scaleTypes = new Object2ObjectOpenHashMap<>();
+	private final Map<ScaleType, ScaleData> pehkui_scaleTypes = new Object2ObjectOpenHashMap<>();
+	private boolean pehkui_typesInitialized = false;
 	private boolean pehkui_shouldSyncScales = false;
 	private boolean pehkui_shouldIgnoreScaleNbt = false;
 	
 	@Override
-	public ScaleData pehkui_constructScaleData(ScaleType type)
-	{
-		return ScaleData.Builder.create().type(type).entity((Entity) (Object) this).build();
-	}
-	
-	@Override
 	public ScaleData pehkui_getScaleData(ScaleType type)
 	{
-		final Map<ScaleType, ScaleData> scaleTypes = pehkui_getScales();
-		
-		synchronized (scaleTypes)
-		{
-			ScaleData scaleData = scaleTypes.get(type);
-			
-			if (scaleData == null && !scaleTypes.containsKey(type))
-			{
-				scaleTypes.put(type, null);
-				scaleTypes.put(type, scaleData = pehkui_constructScaleData(type));
-			}
-			
-			return scaleData;
-		}
+		return pehkui_getScales().get(type);
 	}
 	
 	@Override
 	public Map<ScaleType, ScaleData> pehkui_getScales()
 	{
-		if (pehkui_scaleTypes == null)
+		if (!pehkui_typesInitialized)
 		{
-			synchronized (this)
+			pehkui_typesInitialized = true;
+			
+			for (ScaleType type : ScaleRegistries.SCALE_TYPES.values())
 			{
-				if (pehkui_scaleTypes == null)
-				{
-					pehkui_scaleTypes = new Object2ObjectOpenHashMap<>();
-				}
+				pehkui_scaleTypes.put(type, ScaleData.Builder.create().type(type).entity((Entity) (Object) this).build());
 			}
 		}
 		

--- a/src/main/java/virtuoel/pehkui/util/PehkuiEntityExtensions.java
+++ b/src/main/java/virtuoel/pehkui/util/PehkuiEntityExtensions.java
@@ -8,8 +8,6 @@ import virtuoel.pehkui.api.ScaleType;
 
 public interface PehkuiEntityExtensions
 {
-	ScaleData pehkui_constructScaleData(ScaleType type);
-	
 	ScaleData pehkui_getScaleData(ScaleType type);
 	
 	Map<ScaleType, ScaleData> pehkui_getScales();


### PR DESCRIPTION
[Profile](https://spark.lucko.me/dwydyZzXfV?hl=7359), removing synchronized blocks should save 5.68%

Scales will be almost immediately initialized anyway by a tick. Map was already initialized so that null check on the map is useless if anything? scaleTypes never has a null value (meaningfully) inserted (the builder cannot produce a null value), so the null check and containsKey is useless. I have no clue why synchronized was being used on entry acquisition; it's not like the client thread accesses a server entity or vice versa