### PR TITLE
Add Power/Action/Condition API for Origins Mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ dependencies {
 		}
 
 		if(project.hasProperty("origins_version")) {
-			modImplementation "com.github.apace100:origins-fabric:${project.origins_version}", excludeFabric
+			modImplementation "com.github.apace100:origins-fabric:${project.origins_version}"
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,28 @@ repositories {
 		url = "https://jitpack.io"
 		content {
 			includeGroup "com.github.Virtuoel"
+			includeGroup "com.github.apace100"
+			includeGroup "com.github.DaFuqs"
 		}
 	}
 	maven {
 		name = "GitHub"
 		url = "https://maven.pkg.github.com"
+	}
+	maven {
+		name = "Ladysnake"
+		url = 'https://ladysnake.jfrog.io/artifactory/mods'
+	}
+	maven {
+		name = "Shadaniel"
+		url "https://maven.shedaniel.me/"
+	}
+	maven {
+		name = "JamiesWhiteShirt"
+		url "https://maven.jamieswhiteshirt.com/libs-release"
+		content {
+			includeGroup "com.jamieswhiteshirt"
+		}
 	}
 }
 
@@ -150,6 +167,10 @@ dependencies {
 		
 		if(project.hasProperty("kanos_config_tag")) {
 			include modApi("com.github.Virtuoel:KanosConfig:${kanos_config_tag}", excludeFabric)
+		}
+
+		if(project.hasProperty("origins_version")) {
+			modImplementation "com.github.apace100:origins-fabric:${project.origins_version}", excludeFabric
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,4 +47,5 @@ modmenu_version=5.0.2
 
 kanos_config_tag=0.3.1
 
+origins_version=v1.8.1
 

--- a/src/main/java/virtuoel/pehkui/Pehkui.java
+++ b/src/main/java/virtuoel/pehkui/Pehkui.java
@@ -11,14 +11,7 @@ import virtuoel.pehkui.api.PehkuiConfig;
 import virtuoel.pehkui.api.ScaleTypes;
 import virtuoel.pehkui.origins.PehkuiPowers;
 import virtuoel.pehkui.command.PehkuiEntitySelectorOptions;
-import virtuoel.pehkui.util.CommandUtils;
-import virtuoel.pehkui.util.ConfigSyncUtils;
-import virtuoel.pehkui.util.GravityChangerCompatibility;
-import virtuoel.pehkui.util.IdentityCompatibility;
-import virtuoel.pehkui.util.ImmersivePortalsCompatibility;
-import virtuoel.pehkui.util.ModLoaderUtils;
-import virtuoel.pehkui.util.MulticonnectCompatibility;
-import virtuoel.pehkui.util.ReachEntityAttributesCompatibility;
+import virtuoel.pehkui.util.*;
 
 @ApiStatus.Internal
 public class Pehkui implements ModInitializer
@@ -56,7 +49,7 @@ public class Pehkui implements ModInitializer
 				}
 			});
 		}
-		if (ModLoaderUtils.isModLoaded("origins"))
+		if (ModLoaderUtils.isModLoaded("origins", ">=1.8.0"))
 		{
 			PehkuiPowers.register();
 		}

--- a/src/main/java/virtuoel/pehkui/Pehkui.java
+++ b/src/main/java/virtuoel/pehkui/Pehkui.java
@@ -9,6 +9,7 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.util.Identifier;
 import virtuoel.pehkui.api.PehkuiConfig;
 import virtuoel.pehkui.api.ScaleTypes;
+import virtuoel.pehkui.origins.PehkuiPowers;
 import virtuoel.pehkui.command.PehkuiEntitySelectorOptions;
 import virtuoel.pehkui.util.CommandUtils;
 import virtuoel.pehkui.util.ConfigSyncUtils;
@@ -25,7 +26,7 @@ public class Pehkui implements ModInitializer
 	public static final String MOD_ID = "pehkui";
 	
 	public static final ILogger LOGGER = MixinService.getService().getLogger(MOD_ID);
-	
+
 	public Pehkui()
 	{
 		ScaleTypes.INVALID.getClass();
@@ -54,6 +55,10 @@ public class Pehkui implements ModInitializer
 					ConfigSyncUtils.resetSyncedConfigs();
 				}
 			});
+		}
+		if (ModLoaderUtils.isModLoaded("origins"))
+		{
+			PehkuiPowers.register();
 		}
 		
 		GravityChangerCompatibility.INSTANCE.getClass();

--- a/src/main/java/virtuoel/pehkui/api/ScaleOperation.java
+++ b/src/main/java/virtuoel/pehkui/api/ScaleOperation.java
@@ -1,10 +1,9 @@
 package virtuoel.pehkui.api;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import net.minecraft.util.StringIdentifiable;
 import virtuoel.pehkui.mixin.OperationArgumentTypeAccessor;
 
-public enum ScaleOperation implements StringIdentifiable
+public enum ScaleOperation
 {
 	SET((prev, now) ->
 	{
@@ -36,7 +35,6 @@ public enum ScaleOperation implements StringIdentifiable
 		return (float) Math.pow(prev, now);
 	});
 
-	public static final StringIdentifiable.Codec<ScaleOperation> CODEC = StringIdentifiable.createCodec(ScaleOperation::values);
 	private final Operation operation;
 
 	ScaleOperation(Operation operation)
@@ -61,7 +59,6 @@ public enum ScaleOperation implements StringIdentifiable
 		}
 	}
 
-	@Override
 	public String asString()
 	{
 		return name().toLowerCase();

--- a/src/main/java/virtuoel/pehkui/api/ScaleOperation.java
+++ b/src/main/java/virtuoel/pehkui/api/ScaleOperation.java
@@ -1,0 +1,75 @@
+package virtuoel.pehkui.api;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.util.StringIdentifiable;
+import virtuoel.pehkui.mixin.OperationArgumentTypeAccessor;
+
+public enum ScaleOperation implements StringIdentifiable
+{
+	SET((prev, now) ->
+	{
+		return now;
+	}),
+	ADD((prev, now) ->
+	{
+		return prev + now;
+	}),
+	SUBTRACT((prev, now) ->
+	{
+		return prev - now;
+	}),
+	MULTIPLY((prev, now) ->
+	{
+		return prev * now;
+	}),
+	DIVIDE((prev, now) ->
+	{
+		if (now == 0)
+		{
+			throw new ArithmeticException("Cannot divide by zero");
+		}
+
+		return prev / now;
+	}),
+	POWER((prev, now) ->
+	{
+		return (float) Math.pow(prev, now);
+	});
+
+	public static final StringIdentifiable.Codec<ScaleOperation> CODEC = StringIdentifiable.createCodec(ScaleOperation::values);
+	private final Operation operation;
+
+	ScaleOperation(Operation operation)
+	{
+		this.operation = operation;
+	}
+
+	public float calculate(float scaleData, float value)
+	{
+		return operation.apply(scaleData, value);
+	}
+
+	public float calculateByCommand(float scaleData, float value) throws CommandSyntaxException
+	{
+		try
+		{
+			return calculate(scaleData, value);
+		}
+		catch (ArithmeticException e)
+		{
+			throw OperationArgumentTypeAccessor.getDivisionZeroException().create();
+		}
+	}
+
+	@Override
+	public String asString()
+	{
+		return name().toLowerCase();
+	}
+
+	@FunctionalInterface
+	public interface Operation
+	{
+		float apply(float scaleData, float value);
+	}
+}

--- a/src/main/java/virtuoel/pehkui/command/argument/ScaleOperationArgumentType.java
+++ b/src/main/java/virtuoel/pehkui/command/argument/ScaleOperationArgumentType.java
@@ -13,108 +13,25 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
 import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.EnumArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
+import virtuoel.pehkui.api.ScaleOperation;
 import virtuoel.pehkui.mixin.OperationArgumentTypeAccessor;
 
-public class ScaleOperationArgumentType implements ArgumentType<ScaleOperationArgumentType.Operation>
+public class ScaleOperationArgumentType extends EnumArgumentType<ScaleOperation>
 {
-	private static final String[] SUGGESTIONS = new String[] { "set", "add", "subtract", "multiply", "divide", "power" };
-	
-	private static final Collection<String> EXAMPLES = Arrays.asList(SUGGESTIONS);
-	private static final SimpleCommandExceptionType INVALID_OPERATION = OperationArgumentTypeAccessor.getInvalidOperationException();
-	private static final SimpleCommandExceptionType DIVISION_ZERO_EXCEPTION = OperationArgumentTypeAccessor.getDivisionZeroException();
-	
+	private ScaleOperationArgumentType()
+	{
+		super(ScaleOperation.CODEC, ScaleOperation::values);
+	}
+
 	public static ScaleOperationArgumentType operation()
 	{
 		return new ScaleOperationArgumentType();
 	}
-	
-	public static Operation getOperation(CommandContext<ServerCommandSource> commandContext, String string) throws CommandSyntaxException
+
+	public static ScaleOperation getOperation(CommandContext<ServerCommandSource> context, String id)
 	{
-		return commandContext.getArgument(string, ScaleOperationArgumentType.Operation.class);
-	}
-	
-	@Override
-	public Operation parse(StringReader stringReader) throws CommandSyntaxException
-	{
-		if (!stringReader.canRead())
-		{
-			throw INVALID_OPERATION.create();
-		}
-		else
-		{
-			int i = stringReader.getCursor();
-			
-			while (stringReader.canRead() && stringReader.peek() != ' ')
-			{
-				stringReader.skip();
-			}
-			
-			return getOperator(stringReader.getString().substring(i, stringReader.getCursor()));
-		}
-	}
-	
-	@Override
-	public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder)
-	{
-		return CommandSource.suggestMatching(SUGGESTIONS, builder);
-	}
-	
-	@Override
-	public Collection<String> getExamples()
-	{
-		return EXAMPLES;
-	}
-	
-	private static Operation getOperator(String string) throws CommandSyntaxException
-	{
-		switch (string)
-		{
-			case "set":
-				return (i, j) ->
-				{
-					return j;
-				};
-			case "add":
-				return (i, j) ->
-				{
-					return i + j;
-				};
-			case "subtract":
-				return (i, j) ->
-				{
-					return i - j;
-				};
-			case "multiply":
-				return (i, j) ->
-				{
-					return i * j;
-				};
-			case "divide":
-				return (i, j) ->
-				{
-					if (j == 0)
-					{
-						throw DIVISION_ZERO_EXCEPTION.create();
-					}
-					else
-					{
-						return i / j;
-					}
-				};
-			case "power":
-				return (i, j) ->
-				{
-					return (float) Math.pow(i, j);
-				};
-			default:
-				throw INVALID_OPERATION.create();
-		}
-	}
-	
-	@FunctionalInterface
-	public interface Operation
-	{
-		float apply(float scaleData, float value) throws CommandSyntaxException;
+		return context.getArgument(id, ScaleOperation.class);
 	}
 }

--- a/src/main/java/virtuoel/pehkui/command/argument/ScaleOperationArgumentType.java
+++ b/src/main/java/virtuoel/pehkui/command/argument/ScaleOperationArgumentType.java
@@ -13,25 +13,64 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
 import net.minecraft.command.CommandSource;
-import net.minecraft.command.argument.EnumArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import virtuoel.pehkui.api.ScaleOperation;
 import virtuoel.pehkui.mixin.OperationArgumentTypeAccessor;
 
-public class ScaleOperationArgumentType extends EnumArgumentType<ScaleOperation>
+public class ScaleOperationArgumentType implements ArgumentType<ScaleOperation>
 {
-	private ScaleOperationArgumentType()
-	{
-		super(ScaleOperation.CODEC, ScaleOperation::values);
-	}
-
+	private static final String[] SUGGESTIONS = Arrays.stream(ScaleOperation.values()).map(ScaleOperation::asString).toArray(String[]::new);
+	
+	private static final Collection<String> EXAMPLES = Arrays.asList(SUGGESTIONS);
+	private static final SimpleCommandExceptionType INVALID_OPERATION = OperationArgumentTypeAccessor.getInvalidOperationException();
+	
 	public static ScaleOperationArgumentType operation()
 	{
 		return new ScaleOperationArgumentType();
 	}
-
-	public static ScaleOperation getOperation(CommandContext<ServerCommandSource> context, String id)
+	
+	public static ScaleOperation getOperation(CommandContext<ServerCommandSource> commandContext, String string) throws CommandSyntaxException
 	{
-		return context.getArgument(id, ScaleOperation.class);
+		return commandContext.getArgument(string, ScaleOperation.class);
+	}
+	
+	@Override
+	public ScaleOperation parse(StringReader stringReader) throws CommandSyntaxException
+	{
+		if (!stringReader.canRead())
+		{
+			throw INVALID_OPERATION.create();
+		}
+		else
+		{
+			int i = stringReader.getCursor();
+			
+			while (stringReader.canRead() && stringReader.peek() != ' ')
+			{
+				stringReader.skip();
+			}
+			
+			return getOperator(stringReader.getString().substring(i, stringReader.getCursor()));
+		}
+	}
+	
+	@Override
+	public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder)
+	{
+		return CommandSource.suggestMatching(SUGGESTIONS, builder);
+	}
+	
+	@Override
+	public Collection<String> getExamples()
+	{
+		return EXAMPLES;
+	}
+	
+	private static ScaleOperation getOperator(String string) throws CommandSyntaxException
+	{
+		return Arrays.stream(ScaleOperation.values())
+				.filter(op -> op.asString().equals(string))
+				.findFirst()
+				.orElseThrow(INVALID_OPERATION::create);
 	}
 }

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
@@ -22,7 +22,7 @@ public class PehkuiDataTypes
 			new SerializableData()
 					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
 					.add("value", SerializableDataTypes.FLOAT)
-					.add("persist", SerializableDataTypes.BOOLEAN, true)
+					.add("persistent", SerializableDataTypes.BOOLEAN, true)
 					.add("delay", SerializableDataTypes.INT, 20)
 					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
 			(dataInst) -> new ScaleTransformer(
@@ -37,7 +37,7 @@ public class PehkuiDataTypes
 				SerializableData.Instance dataInst = data.new Instance();
 				dataInst.set("scale", inst.getScaleType());
 				dataInst.set("value", inst.getValue());
-				dataInst.set("persist", inst.shouldPersist());
+				dataInst.set("persistent", inst.shouldPersist());
 				dataInst.set("delay", inst.getDelay());
 				dataInst.set("easing", inst.getEasing());
 				return dataInst;
@@ -48,7 +48,7 @@ public class PehkuiDataTypes
 			new SerializableData()
 					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
 					.add("value", SerializableDataTypes.FLOAT)
-					.add("persist", SerializableDataTypes.BOOLEAN, true)
+					.add("persistent", SerializableDataTypes.BOOLEAN, true)
 					.add("operation", SCALE_OPERATION, ScaleOperation.SET)
 					.add("delay", SerializableDataTypes.INT, 20)
 					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
@@ -66,7 +66,7 @@ public class PehkuiDataTypes
 				dataInst.set("scale", inst.getScaleType());
 				dataInst.set("value", inst.getValue());
 				dataInst.set("operation", inst.getOperation());
-				dataInst.set("persist", inst.shouldPersist());
+				dataInst.set("persistent", inst.shouldPersist());
 				dataInst.set("delay", inst.getDelay());
 				dataInst.set("easing", inst.getEasing());
 				return dataInst;

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
@@ -22,12 +22,14 @@ public class PehkuiDataTypes
 			new SerializableData()
 					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
 					.add("value", SerializableDataTypes.FLOAT)
+					.add("persist", SerializableDataTypes.BOOLEAN, true)
 					.add("delay", SerializableDataTypes.INT, 20)
 					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
 			(dataInst) -> new ScaleTransformer(
 					dataInst.get("scale"),
 					dataInst.getFloat("value"),
 					ScaleOperation.SET,
+					dataInst.getBoolean("persist"),
 					dataInst.getInt("delay"),
 					dataInst.get("easing")),
 			(data, inst) ->
@@ -35,6 +37,7 @@ public class PehkuiDataTypes
 				SerializableData.Instance dataInst = data.new Instance();
 				dataInst.set("scale", inst.getScaleType());
 				dataInst.set("value", inst.getValue());
+				dataInst.set("persist", inst.shouldPersist());
 				dataInst.set("delay", inst.getDelay());
 				dataInst.set("easing", inst.getEasing());
 				return dataInst;
@@ -45,6 +48,7 @@ public class PehkuiDataTypes
 			new SerializableData()
 					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
 					.add("value", SerializableDataTypes.FLOAT)
+					.add("persist", SerializableDataTypes.BOOLEAN, true)
 					.add("operation", SCALE_OPERATION, ScaleOperation.SET)
 					.add("delay", SerializableDataTypes.INT, 20)
 					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
@@ -52,6 +56,7 @@ public class PehkuiDataTypes
 					dataInst.get("scale"),
 					dataInst.getFloat("value"),
 					dataInst.get("operation"),
+					dataInst.getBoolean("persist"),
 					dataInst.getInt("delay"),
 					dataInst.get("easing")),
 			(data, inst) ->
@@ -61,6 +66,7 @@ public class PehkuiDataTypes
 				dataInst.set("scale", inst.getScaleType());
 				dataInst.set("value", inst.getValue());
 				dataInst.set("operation", inst.getOperation());
+				dataInst.set("persist", inst.shouldPersist());
 				dataInst.set("delay", inst.getDelay());
 				dataInst.set("easing", inst.getEasing());
 				return dataInst;

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiDataTypes.java
@@ -1,0 +1,74 @@
+package virtuoel.pehkui.origins;
+
+import com.google.common.collect.BiMap;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import it.unimi.dsi.fastutil.floats.Float2FloatFunction;
+import net.minecraft.util.Identifier;
+import virtuoel.pehkui.api.*;
+
+import java.util.List;
+
+public class PehkuiDataTypes
+{
+
+	public static final SerializableDataType<ScaleType> SCALE_TYPE = registry(ScaleType.class, ScaleRegistries.SCALE_TYPES);
+	public static final SerializableDataType<Float2FloatFunction> SCALE_EASING = registry(Float2FloatFunction.class, ScaleRegistries.SCALE_EASINGS);
+
+	public static final SerializableDataType<ScaleOperation> SCALE_OPERATION = SerializableDataType.enumValue(ScaleOperation.class);
+	public static final SerializableDataType<ScaleTransformer> SCALE_TRANSFORMER = SerializableDataType.compound(
+			ScaleTransformer.class,
+			new SerializableData()
+					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
+					.add("value", SerializableDataTypes.FLOAT)
+					.add("delay", SerializableDataTypes.INT, 20)
+					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
+			(dataInst) -> new ScaleTransformer(
+					dataInst.get("scale"),
+					dataInst.getFloat("value"),
+					ScaleOperation.SET,
+					dataInst.getInt("delay"),
+					dataInst.get("easing")),
+			(data, inst) ->
+			{
+				SerializableData.Instance dataInst = data.new Instance();
+				dataInst.set("scale", inst.getScaleType());
+				dataInst.set("value", inst.getValue());
+				dataInst.set("delay", inst.getDelay());
+				dataInst.set("easing", inst.getEasing());
+				return dataInst;
+			});
+	public static final SerializableDataType<List<ScaleTransformer>> SCALE_TRANSFORMERS = SerializableDataType.list(SCALE_TRANSFORMER);
+	public static final SerializableDataType<ScaleTransformer> SCALE_TRANSFORMER_WITH_OPERATION = SerializableDataType.compound(
+			ScaleTransformer.class,
+			new SerializableData()
+					.add("scale", SCALE_TYPE, ScaleTypes.BASE)
+					.add("value", SerializableDataTypes.FLOAT)
+					.add("operation", SCALE_OPERATION, ScaleOperation.SET)
+					.add("delay", SerializableDataTypes.INT, 20)
+					.add("easing", SCALE_EASING, ScaleEasings.LINEAR),
+			(dataInst) -> new ScaleTransformer(
+					dataInst.get("scale"),
+					dataInst.getFloat("value"),
+					dataInst.get("operation"),
+					dataInst.getInt("delay"),
+					dataInst.get("easing")),
+			(data, inst) ->
+			{
+
+				SerializableData.Instance dataInst = data.new Instance();
+				dataInst.set("scale", inst.getScaleType());
+				dataInst.set("value", inst.getValue());
+				dataInst.set("operation", inst.getOperation());
+				dataInst.set("delay", inst.getDelay());
+				dataInst.set("easing", inst.getEasing());
+				return dataInst;
+			});
+	public static final SerializableDataType<List<ScaleTransformer>> SCALE_TRANSFORMERS_WITH_OPERATION = SerializableDataType.list(SCALE_TRANSFORMER_WITH_OPERATION);
+
+	private static <T> SerializableDataType<T> registry(Class<T> clazz, BiMap<Identifier, T> registry)
+	{
+		return SerializableDataType.wrap(clazz, SerializableDataTypes.IDENTIFIER, entry -> registry.inverse().get(entry), registry::get);
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
@@ -1,0 +1,18 @@
+package virtuoel.pehkui.origins;
+
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.registry.ApoliRegistries;
+import net.minecraft.registry.Registry;
+
+public class PehkuiPowers
+{
+	public static void register()
+	{
+		registerPower(ScalePower.createFactory());
+	}
+
+	private static void registerPower(PowerFactory<?> powerFactory)
+	{
+		Registry.register(ApoliRegistries.POWER_FACTORY, powerFactory.getSerializerId(), powerFactory);
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
@@ -1,8 +1,8 @@
 package virtuoel.pehkui.origins;
 
-import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.factory.PowerFactory;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.calio.data.SerializableData;
 import net.minecraft.entity.Entity;
@@ -11,6 +11,7 @@ import net.minecraft.util.Identifier;
 import virtuoel.pehkui.Pehkui;
 
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public class PehkuiPowers
 {
@@ -18,6 +19,7 @@ public class PehkuiPowers
 	{
 		registerPower(ScalePower.createFactory());
 		registerEntityAction("scale", ScaleEntityAction.DATA, new ScaleEntityAction());
+		registerEntityCondition("scale", ScaleEntityCondition.DATA, new ScaleEntityCondition());
 	}
 
 	private static void registerPower(PowerFactory<?> powerFactory)
@@ -29,5 +31,11 @@ public class PehkuiPowers
 	{
 		Identifier id = Pehkui.id(path);
 		Registry.register(ApoliRegistries.ENTITY_ACTION, id, new ActionFactory<>(id, data, effect));
+	}
+
+	private static void registerEntityCondition(String path, SerializableData data, BiFunction<SerializableData.Instance, Entity, Boolean> effect)
+	{
+		Identifier id = Pehkui.id(path);
+		Registry.register(ApoliRegistries.ENTITY_CONDITION, id, new ConditionFactory<>(id, data, effect));
 	}
 }

--- a/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
+++ b/src/main/java/virtuoel/pehkui/origins/PehkuiPowers.java
@@ -1,18 +1,33 @@
 package virtuoel.pehkui.origins;
 
+import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.apoli.registry.ApoliRegistries;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
 import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+import virtuoel.pehkui.Pehkui;
+
+import java.util.function.BiConsumer;
 
 public class PehkuiPowers
 {
 	public static void register()
 	{
 		registerPower(ScalePower.createFactory());
+		registerEntityAction("scale", ScaleEntityAction.DATA, new ScaleEntityAction());
 	}
 
 	private static void registerPower(PowerFactory<?> powerFactory)
 	{
 		Registry.register(ApoliRegistries.POWER_FACTORY, powerFactory.getSerializerId(), powerFactory);
+	}
+
+	private static void registerEntityAction(String path, SerializableData data, BiConsumer<SerializableData.Instance, Entity> effect)
+	{
+		Identifier id = Pehkui.id(path);
+		Registry.register(ApoliRegistries.ENTITY_ACTION, id, new ActionFactory<>(id, data, effect));
 	}
 }

--- a/src/main/java/virtuoel/pehkui/origins/ScaleEntityAction.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleEntityAction.java
@@ -1,0 +1,23 @@
+package virtuoel.pehkui.origins;
+
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class ScaleEntityAction implements BiConsumer<SerializableData.Instance, Entity>
+{
+	public static final SerializableData DATA = new SerializableData()
+			.add("transformer", PehkuiDataTypes.SCALE_TRANSFORMER_WITH_OPERATION, null)
+			.add("transformers", PehkuiDataTypes.SCALE_TRANSFORMERS_WITH_OPERATION, null);
+
+	@Override
+	public void accept(SerializableData.Instance data, Entity entity)
+	{
+		if (data.isPresent("transformer"))
+			data.<ScaleTransformer>get("transformer").applyTo(entity);
+		if (data.isPresent("transformers"))
+			data.<List<ScaleTransformer>>get("transformers").forEach(transformer -> transformer.applyTo(entity));
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/ScaleEntityCondition.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleEntityCondition.java
@@ -5,7 +5,6 @@ import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.mob.CreeperEntity;
 import virtuoel.pehkui.api.ScaleData;
 import virtuoel.pehkui.api.ScaleType;
 

--- a/src/main/java/virtuoel/pehkui/origins/ScaleEntityCondition.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleEntityCondition.java
@@ -1,0 +1,33 @@
+package virtuoel.pehkui.origins;
+
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.CreeperEntity;
+import virtuoel.pehkui.api.ScaleData;
+import virtuoel.pehkui.api.ScaleType;
+
+import java.util.function.BiFunction;
+
+public class ScaleEntityCondition implements BiFunction<SerializableData.Instance, Entity, Boolean>
+{
+	public static final SerializableData DATA = new SerializableData()
+			.add("scale", PehkuiDataTypes.SCALE_TYPE)
+			.add("use_target_value", SerializableDataTypes.BOOLEAN, false)
+			.add("comparison", ApoliDataTypes.COMPARISON)
+			.add("compare_to", SerializableDataTypes.FLOAT);
+
+	@Override
+	public Boolean apply(SerializableData.Instance data, Entity entity)
+	{
+		ScaleType scaleType = data.get("scale");
+		Comparison comparison = data.get("comparison");
+		float compareTo = data.getFloat("compare_to");
+
+		ScaleData scaleData = scaleType.getScaleData(entity);
+		float value = data.getBoolean("use_target_value") ? scaleData.getTargetScale() : scaleData.getScale();
+		return comparison.compare(value, compareTo);
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/ScalePower.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScalePower.java
@@ -1,0 +1,61 @@
+package virtuoel.pehkui.origins;
+
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.power.Power;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.LivingEntity;
+import virtuoel.pehkui.Pehkui;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ScalePower extends Power
+{
+
+	private final List<ScaleTransformer> transformers;
+
+	public ScalePower(PowerType<?> type, LivingEntity entity, List<ScaleTransformer> transformers)
+	{
+		super(type, entity);
+		this.transformers = transformers;
+	}
+
+	@Override
+	public void onGained()
+	{
+		for (ScaleTransformer transformer : transformers)
+			transformer.applyTo(entity);
+	}
+
+	@Override
+	public void onLost()
+	{
+		List<ScalePower> scalePowers = PowerHolderComponent.getPowers(entity, ScalePower.class);
+		for (ScaleTransformer transformer : transformers) {
+			boolean shouldReset = scalePowers.stream().noneMatch(power -> power != this && power.transformers.stream().anyMatch(t -> t.getScaleType() == transformer.getScaleType())
+			);
+			if (shouldReset) // only reset if no other (new) powers are applying a transformer of the same scale type because onGained is called before onLost
+				transformer.reset(entity);
+		}
+	}
+
+	public static PowerFactory<ScalePower> createFactory()
+	{
+		return new PowerFactory<>(
+				Pehkui.id("scale"),
+				new SerializableData()
+						.add("transformer", PehkuiDataTypes.SCALE_TRANSFORMER, null)
+						.add("transformers", PehkuiDataTypes.SCALE_TRANSFORMERS, null),
+				data -> (type, entity) ->
+				{
+					if (data.isPresent("transformer"))
+						return new ScalePower(type, entity, Collections.singletonList(data.get("transformer")));
+					if (data.isPresent("transformers"))
+						return new ScalePower(type, entity, data.get("transformers"));
+					return new ScalePower(type, entity, Collections.emptyList());
+				}
+		);
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/ScalePower.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScalePower.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 public class ScalePower extends Power
 {
-
 	private final List<ScaleTransformer> transformers;
 
 	public ScalePower(PowerType<?> type, LivingEntity entity, List<ScaleTransformer> transformers)
@@ -39,9 +38,9 @@ public class ScalePower extends Power
 	public void onLost()
 	{
 		List<ScalePower> scalePowers = PowerHolderComponent.getPowers(entity, ScalePower.class);
-		for (ScaleTransformer transformer : transformers) {
-			boolean shouldReset = scalePowers.stream().noneMatch(power -> power != this && power.transformers.stream().anyMatch(t -> t.getScaleType() == transformer.getScaleType())
-			);
+		for (ScaleTransformer transformer : transformers)
+		{
+			boolean shouldReset = scalePowers.stream().noneMatch(power -> power != this && power.transformers.stream().anyMatch(t -> t.getScaleType() == transformer.getScaleType()));
 			if (shouldReset) // only reset if no other (new) powers are applying a transformer of the same scale type because onGained is called before onLost
 				transformer.reset(entity);
 		}

--- a/src/main/java/virtuoel/pehkui/origins/ScalePower.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScalePower.java
@@ -30,6 +30,12 @@ public class ScalePower extends Power
 	}
 
 	@Override
+	public void onRespawn()
+	{
+		onGained();
+	}
+
+	@Override
 	public void onLost()
 	{
 		List<ScalePower> scalePowers = PowerHolderComponent.getPowers(entity, ScalePower.class);

--- a/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
@@ -12,16 +12,16 @@ public class ScaleTransformer
 	private final ScaleType scaleType;
 	private final float value;
 	private final ScaleOperation operation;
-	private final boolean persist;
+	private final boolean persistent;
 	private final int delay;
 	private final Float2FloatFunction easing;
 
-	public ScaleTransformer(ScaleType scaleType, float value, ScaleOperation operation, boolean persist, int delay, Float2FloatFunction easing)
+	public ScaleTransformer(ScaleType scaleType, float value, ScaleOperation operation, boolean persistent, int delay, Float2FloatFunction easing)
 	{
 		this.scaleType = scaleType;
 		this.value = value;
 		this.operation = operation;
-		this.persist = persist;
+		this.persistent = persistent;
 		this.delay = delay;
 		this.easing = easing;
 	}
@@ -33,6 +33,7 @@ public class ScaleTransformer
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
 		data.setEasing(easing);
+		data.setPersistence(persistent);
 		data.setTargetScale(operation.calculate(data.getTargetScale(), value));
 	}
 
@@ -43,6 +44,7 @@ public class ScaleTransformer
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
 		data.setEasing(easing);
+		data.setPersistence(persistent);
 		data.setTargetScale(1.0F);
 	}
 
@@ -63,7 +65,7 @@ public class ScaleTransformer
 
 	public boolean shouldPersist()
 	{
-		return persist;
+		return persistent;
 	}
 
 	public int getDelay()

--- a/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
@@ -1,0 +1,67 @@
+package virtuoel.pehkui.origins;
+
+import it.unimi.dsi.fastutil.floats.Float2FloatFunction;
+import net.minecraft.entity.LivingEntity;
+import virtuoel.pehkui.api.ScaleData;
+import virtuoel.pehkui.api.ScaleOperation;
+import virtuoel.pehkui.api.ScaleType;
+
+public class ScaleTransformer
+{
+
+	private final ScaleType scaleType;
+	private final float value;
+	private final ScaleOperation operation;
+	private final int delay;
+	private final Float2FloatFunction easing;
+
+	public ScaleTransformer(ScaleType scaleType, float value, ScaleOperation operation, int delay, Float2FloatFunction easing)
+	{
+		this.scaleType = scaleType;
+		this.value = value;
+		this.operation = operation;
+		this.delay = delay;
+		this.easing = easing;
+	}
+
+	public void applyTo(LivingEntity entity)
+	{
+		ScaleData data = scaleType.getScaleData(entity);
+		data.setScaleTickDelay(delay);
+		data.setEasing(easing);
+		data.setTargetScale(operation.calculate(data.getTargetScale(), value));
+	}
+
+	public void reset(LivingEntity entity)
+	{
+		ScaleData data = scaleType.getScaleData(entity);
+		data.setScaleTickDelay(delay);
+		data.setEasing(easing);
+		data.setTargetScale(1.0F);
+	}
+
+	public ScaleType getScaleType()
+	{
+		return scaleType;
+	}
+
+	public float getValue()
+	{
+		return value;
+	}
+
+	public ScaleOperation getOperation()
+	{
+		return operation;
+	}
+
+	public int getDelay()
+	{
+		return delay;
+	}
+
+	public Float2FloatFunction getEasing()
+	{
+		return easing;
+	}
+}

--- a/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
@@ -28,6 +28,8 @@ public class ScaleTransformer
 
 	public void applyTo(Entity entity)
 	{
+		if (entity.world.isClient)
+			return;
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
 		data.setEasing(easing);
@@ -36,6 +38,8 @@ public class ScaleTransformer
 
 	public void reset(Entity entity)
 	{
+		if (entity.world.isClient)
+			return;
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
 		data.setEasing(easing);

--- a/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
+++ b/src/main/java/virtuoel/pehkui/origins/ScaleTransformer.java
@@ -1,7 +1,7 @@
 package virtuoel.pehkui.origins;
 
 import it.unimi.dsi.fastutil.floats.Float2FloatFunction;
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.Entity;
 import virtuoel.pehkui.api.ScaleData;
 import virtuoel.pehkui.api.ScaleOperation;
 import virtuoel.pehkui.api.ScaleType;
@@ -12,19 +12,21 @@ public class ScaleTransformer
 	private final ScaleType scaleType;
 	private final float value;
 	private final ScaleOperation operation;
+	private final boolean persist;
 	private final int delay;
 	private final Float2FloatFunction easing;
 
-	public ScaleTransformer(ScaleType scaleType, float value, ScaleOperation operation, int delay, Float2FloatFunction easing)
+	public ScaleTransformer(ScaleType scaleType, float value, ScaleOperation operation, boolean persist, int delay, Float2FloatFunction easing)
 	{
 		this.scaleType = scaleType;
 		this.value = value;
 		this.operation = operation;
+		this.persist = persist;
 		this.delay = delay;
 		this.easing = easing;
 	}
 
-	public void applyTo(LivingEntity entity)
+	public void applyTo(Entity entity)
 	{
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
@@ -32,7 +34,7 @@ public class ScaleTransformer
 		data.setTargetScale(operation.calculate(data.getTargetScale(), value));
 	}
 
-	public void reset(LivingEntity entity)
+	public void reset(Entity entity)
 	{
 		ScaleData data = scaleType.getScaleData(entity);
 		data.setScaleTickDelay(delay);
@@ -53,6 +55,11 @@ public class ScaleTransformer
 	public ScaleOperation getOperation()
 	{
 		return operation;
+	}
+
+	public boolean shouldPersist()
+	{
+		return persist;
 	}
 
 	public int getDelay()

--- a/src/main/java/virtuoel/pehkui/server/command/ScaleCommand.java
+++ b/src/main/java/virtuoel/pehkui/server/command/ScaleCommand.java
@@ -25,12 +25,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
-import virtuoel.pehkui.api.PehkuiConfig;
-import virtuoel.pehkui.api.ScaleData;
-import virtuoel.pehkui.api.ScaleModifier;
-import virtuoel.pehkui.api.ScaleRegistries;
-import virtuoel.pehkui.api.ScaleType;
-import virtuoel.pehkui.api.ScaleTypes;
+import virtuoel.pehkui.api.*;
 import virtuoel.pehkui.command.argument.ScaleEasingArgumentType;
 import virtuoel.pehkui.command.argument.ScaleModifierArgumentType;
 import virtuoel.pehkui.command.argument.ScaleOperationArgumentType;
@@ -84,9 +79,9 @@ public class ScaleCommand
 								for (final Entity e : EntityArgumentType.getEntities(context, "targets"))
 								{
 									final ScaleData data = type.getScaleData(e);
-									final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
+									final ScaleOperation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 									
-									data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+									data.setTargetScale(operation.calculateByCommand(data.getTargetScale(), scale));
 								}
 								
 								return 1;
@@ -98,9 +93,9 @@ public class ScaleCommand
 							final ScaleType type = ScaleTypeArgumentType.getScaleTypeArgument(context, "scale_type");
 							
 							final ScaleData data = type.getScaleData(context.getSource().getEntityOrThrow());
-							final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
+							final ScaleOperation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 							
-							data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+							data.setTargetScale(operation.calculateByCommand(data.getTargetScale(), scale));
 							
 							return 1;
 						})
@@ -115,9 +110,9 @@ public class ScaleCommand
 							for (final Entity e : EntityArgumentType.getEntities(context, "targets"))
 							{
 								final ScaleData data = ScaleTypes.BASE.getScaleData(e);
-								final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
+								final ScaleOperation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 								
-								data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+								data.setTargetScale(operation.calculateByCommand(data.getTargetScale(), scale));
 							}
 							
 							return 1;
@@ -128,9 +123,9 @@ public class ScaleCommand
 						final float scale = FloatArgumentType.getFloat(context, "value");
 						
 						final ScaleData data = ScaleTypes.BASE.getScaleData(context.getSource().getEntityOrThrow());
-						final ScaleOperationArgumentType.Operation operation = ScaleOperationArgumentType.getOperation(context, "operation");
+						final ScaleOperation operation = ScaleOperationArgumentType.getOperation(context, "operation");
 						
-						data.setTargetScale(operation.apply(data.getTargetScale(), scale));
+						data.setTargetScale(operation.calculateByCommand(data.getTargetScale(), scale));
 						
 						return 1;
 					})
@@ -155,8 +150,8 @@ public class ScaleCommand
 											final float minValue = FloatArgumentType.getFloat(context, "minValue");
 											final float maxValue = FloatArgumentType.getFloat(context, "maxValue");
 											
-											final ScaleOperationArgumentType.Operation minOperation = ScaleOperationArgumentType.getOperation(context, "minOperation");
-											final ScaleOperationArgumentType.Operation maxOperation = ScaleOperationArgumentType.getOperation(context, "maxOperation");
+											final ScaleOperation minOperation = ScaleOperationArgumentType.getOperation(context, "minOperation");
+											final ScaleOperation maxOperation = ScaleOperationArgumentType.getOperation(context, "maxOperation");
 											
 											final ScaleType type = ScaleTypeArgumentType.getScaleTypeArgument(context, "scale_type");
 											
@@ -166,8 +161,8 @@ public class ScaleCommand
 												final ScaleData data = type.getScaleData(e);
 												
 												target = data.getTargetScale();
-												min = minOperation.apply(target, minValue);
-												max = maxOperation.apply(target, maxValue);
+												min = minOperation.calculateByCommand(target, minValue);
+												max = maxOperation.calculateByCommand(target, maxValue);
 												
 												if (max < min)
 												{
@@ -187,16 +182,16 @@ public class ScaleCommand
 										final float minValue = FloatArgumentType.getFloat(context, "minValue");
 										final float maxValue = FloatArgumentType.getFloat(context, "maxValue");
 										
-										final ScaleOperationArgumentType.Operation minOperation = ScaleOperationArgumentType.getOperation(context, "minOperation");
-										final ScaleOperationArgumentType.Operation maxOperation = ScaleOperationArgumentType.getOperation(context, "maxOperation");
+										final ScaleOperation minOperation = ScaleOperationArgumentType.getOperation(context, "minOperation");
+										final ScaleOperation maxOperation = ScaleOperationArgumentType.getOperation(context, "maxOperation");
 										
 										final ScaleType type = ScaleTypeArgumentType.getScaleTypeArgument(context, "scale_type");
 										
 										final ScaleData data = type.getScaleData(context.getSource().getEntityOrThrow());
 										
 										final float target = data.getTargetScale();
-										float min = minOperation.apply(target, minValue);
-										float max = maxOperation.apply(target, maxValue);
+										float min = minOperation.calculateByCommand(target, minValue);
+										float max = maxOperation.calculateByCommand(target, maxValue);
 										
 										if (max < min)
 										{

--- a/src/main/java/virtuoel/pehkui/util/ModLoaderUtils.java
+++ b/src/main/java/virtuoel/pehkui/util/ModLoaderUtils.java
@@ -1,11 +1,30 @@
 package virtuoel.pehkui.util;
 
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.version.VersionPredicate;
 
 public class ModLoaderUtils
 {
 	public static boolean isModLoaded(final String modId)
 	{
 		return FabricLoader.getInstance().isModLoaded(modId);
+	}
+
+	public static boolean isModLoaded(final String modId, final String version)
+	{
+		try
+		{
+			VersionPredicate parsedVersion = VersionPredicate.parse(version);
+
+			return FabricLoader.getInstance().getModContainer(modId).map(c ->
+			{
+				return parsedVersion.test(c.getMetadata().getVersion());
+			}).orElse(false);
+		}
+		catch (VersionParsingException e)
+		{
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,9 @@
 		"fabric-api-base": "*",
 		"kanos_config": ">=0.3.1"
 	},
+	"suggests": {
+		"origins": "*"
+	},
 	"entrypoints":
 	{
 		"main":


### PR DESCRIPTION
This PR adds a power, entity action, and entity condition to the Origins mod (if present) to simplify the process of changing the player's size.
As of right now, datapack creators have to execute a command to achieve this but this can cause some issues e.g. the player's size not being correctly set when changing origins.

I've tested the mod for Minecraft 1.14.4 up to 1.19.3. Though, the feature itself only works for 1.19.3 as of now. I'm not sure how to handle the compatibility for older versions of Origins.
Here is an example datapack I've used to test those features: [Pehkui Origin Test.zip](https://github.com/Virtuoel/Pehkui/files/10714743/Pehkui.Origin.Test.zip)
